### PR TITLE
Add redirect_uri to access_token params

### DIFF
--- a/lib/auth/oauth_gems.rb
+++ b/lib/auth/oauth_gems.rb
@@ -226,5 +226,10 @@ class OmniAuth::Strategies::Weibo < OmniAuth::Strategies::OAuth2
       end
     end
   end
+
+  def callback_url
+    options[:redirect_uri] || (full_host + script_name + callback_path)
+  end
+
 end
 


### PR DESCRIPTION
This change is to overcome `redirect_uri` missing issue caused by this commit in omniauth-oauth2: https://github.com/intridea/omniauth-oauth2/commit/26152673224aca5c3e918bcc83075dbb0659717f#diff-1894759d724182a93ca97be91b43a7bc

`callback_url` is added back to build up access_token params for weibo strategy.